### PR TITLE
apis, schemas, websocket: Set speach 1.6 default

### DIFF
--- a/src/fish_audio_sdk/apis.py
+++ b/src/fish_audio_sdk/apis.py
@@ -17,7 +17,7 @@ from .schemas import (
 
 class Session(RemoteCall):
     @convert_stream
-    def tts(self, request: TTSRequest, backend: Backends = "speech-1.5") -> GStream:
+    def tts(self, request: TTSRequest, backend: Backends = "speech-1.6") -> GStream:
         yield Request(
             method="POST",
             url="/v1/tts",

--- a/src/fish_audio_sdk/schemas.py
+++ b/src/fish_audio_sdk/schemas.py
@@ -5,7 +5,7 @@ from typing import Annotated, Generic, Literal, TypeVar
 from pydantic import BaseModel, Field
 
 
-Backends = Literal["speech-1.5", "agent-x0"]
+Backends = Literal["speech-1.6", "agent-x0"]
 
 Item = TypeVar("Item")
 

--- a/src/fish_audio_sdk/websocket.py
+++ b/src/fish_audio_sdk/websocket.py
@@ -40,7 +40,7 @@ class WebSocketSession:
         self,
         request: TTSRequest,
         text_stream: Iterable[str],
-        backend: Backends = "speech-1.5",
+        backend: Backends = "speech-1.6",
     ) -> Generator[bytes, None, None]:
         with connect_ws(
             "/v1/tts/live",
@@ -112,7 +112,7 @@ class AsyncWebSocketSession:
         self,
         request: TTSRequest,
         text_stream: AsyncIterable[str],
-        backend: Backends = "speech-1.5",
+        backend: Backends = "speech-1.6",
     ) -> AsyncGenerator[bytes, None]:
         async with aconnect_ws(
             "/v1/tts/live",


### PR DESCRIPTION
The default endpoint was speach 1.5. I changed the default here to 1.6 1.5 is still supported. The caller can pass the backend they want to use. Tested and working. Noticing much better cadence in 1.6 and less aberration in audio

This should close https://github.com/fishaudio/fish-audio-python/issues/18