### PR TITLE
Feat: model 1 6 supported and more control parameters

### DIFF
--- a/src/fish_audio_sdk/schemas.py
+++ b/src/fish_audio_sdk/schemas.py
@@ -37,6 +37,8 @@ class TTSRequest(BaseModel):
     normalize: bool = True
     latency: Literal["normal", "balanced"] = "balanced"
     prosody: Prosody | None = None
+    top_p: float = 0.7
+    temperature: float = 0.7
 
 
 class ASRRequest(BaseModel):

--- a/src/fish_audio_sdk/schemas.py
+++ b/src/fish_audio_sdk/schemas.py
@@ -5,7 +5,7 @@ from typing import Annotated, Generic, Literal, TypeVar
 from pydantic import BaseModel, Field
 
 
-Backends = Literal["speech-1.5", "agent-x0"]
+Backends = Literal["speech-1.5", "speech-1.6", "agent-x0"]
 
 Item = TypeVar("Item")
 

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -10,6 +10,12 @@ def test_tts(session: Session):
         buffer.extend(chunk)
     assert len(buffer) > 0
 
+def test_tts_model_1_6(session: Session):
+    buffer = bytearray()
+    for chunk in session.tts(TTSRequest(text="Hello, world!"), backend="speech-1.6"):
+        buffer.extend(chunk)
+    assert len(buffer) > 0
+
 
 async def test_tts_async(session: Session):
     buffer = bytearray()


### PR DESCRIPTION
- add `model 1.6` into `TTSRequest` to support new released model
- add parameters `temperature` and `top_p` into `TTSRequest` to allow user control the flexibility of audio generation 