### PR TITLE
Export WebSocketErr in public API

### DIFF
--- a/src/fish_audio_sdk/__init__.py
+++ b/src/fish_audio_sdk/__init__.py
@@ -1,11 +1,12 @@
 from .apis import Session
-from .exceptions import HttpCodeErr
+from .exceptions import HttpCodeErr, WebSocketErr
 from .schemas import ASRRequest, TTSRequest, ReferenceAudio, Prosody, PaginatedResponse, ModelEntity, APICreditEntity, StartEvent, TextEvent, CloseEvent
 from .websocket import WebSocketSession, AsyncWebSocketSession
 
 __all__ = [
     "Session",
     "HttpCodeErr",
+    "WebSocketErr",
     "ReferenceAudio",
     "TTSRequest",
     "ASRRequest",


### PR DESCRIPTION
This PR exports `WebSocketErr` exception in the package's public API (`__all__`), making it accessible for proper error handling in downstream projects.

## Problem

The `WebSocketErr` exception is defined in `exceptions.py` and raised in `websocket.py` during WebSocket operations, but it's not exported in the package's `__all__` list.

Currently, users must use internal imports:
```python
from fish_audio_sdk.exceptions import WebSocketErr  # Internal import
```

## Solution

Added `WebSocketErr` to the `__all__` list in `__init__.py` to make it part of the public API.

## Usage Example

**After this change:**
```python
from fish_audio_sdk import AsyncWebSocketSession, WebSocketErr

try:
    async with AsyncWebSocketSession(apikey="...") as session:
        # ... use session
except WebSocketErr as e:
    print(f"WebSocket error: {e}")
```