### PR TITLE
fix: allow non `s` prefixed models to fail websocket integration tests

### DIFF
--- a/tests/integration/test_tts_websocket_integration.py
+++ b/tests/integration/test_tts_websocket_integration.py
@@ -39,7 +39,10 @@ class TestTTSWebSocketIntegration:
         "model",
         [
             pytest.param(
-                m, marks=pytest.mark.xfail(reason="WebSocket unreliable for legacy models")
+                m,
+                marks=pytest.mark.xfail(
+                    reason="WebSocket unreliable for legacy models"
+                ),
             )
             if not m.startswith("s1")
             else m
@@ -228,7 +231,10 @@ class TestAsyncTTSWebSocketIntegration:
         "model",
         [
             pytest.param(
-                m, marks=pytest.mark.xfail(reason="WebSocket unreliable for legacy models")
+                m,
+                marks=pytest.mark.xfail(
+                    reason="WebSocket unreliable for legacy models"
+                ),
             )
             if not m.startswith("s1")
             else m


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Refactored WebSocket streaming tests to provide consistent, model-specific validation across different scenarios.
  * Enhanced test reporting by explicitly marking known unstable model scenarios as expected failures, improving clarity and reliability of test results.
  * Simplified test execution flow while maintaining comprehensive coverage validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->